### PR TITLE
Allowing DataFrames where all columns are DoubleType to be a source for RowPartitionedMatrix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalaVersion := "2.10.4"
 parallelExecution in Test := false
 
 {
-  val defaultSparkVersion = "1.2.1"
+  val defaultSparkVersion = "1.3.1"
   val sparkVersion = scala.util.Properties.envOrElse("SPARK_VERSION", defaultSparkVersion)
   val excludeHadoop = ExclusionRule(organization = "org.apache.hadoop")
   libraryDependencies ++= Seq(

--- a/src/test/scala/edu/berkeley/cs/amplab/mlmatrix/RowPartitionedMatrixSuite.scala
+++ b/src/test/scala/edu/berkeley/cs/amplab/mlmatrix/RowPartitionedMatrixSuite.scala
@@ -5,6 +5,9 @@ import org.scalatest.FunSuite
 import breeze.linalg._
 
 import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{SQLContext, DataFrame, Row}
+import org.apache.spark.sql.types._
 
 class RowPartitionedMatrixSuite extends FunSuite with LocalSparkContext with Logging {
 
@@ -102,20 +105,20 @@ class RowPartitionedMatrixSuite extends FunSuite with LocalSparkContext with Log
     sc = new SparkContext("local", "test")
     val sqlContext = new SQLContext(sc)
     val testRDD = sc.parallelize(Seq(
-        Array(1, 2, 3),
-        Array(1, 9, -1),
-        Array(0, 0, 1),
-        Array(0, 1, 0)
+        Array(1.0, 2.0, 3.0),
+        Array(1.0, 9.0, -1.0),
+        Array(0.0, 0.0, 1.0),
+        Array(0.0, 1.0, 0.0)
     )).map(x => Row(x(0), x(1), x(2)))
     val testSchema = StructType(
         StructField("v1", DoubleType, true) ::
         StructField("v2", DoubleType, true) ::
         StructField("v3", DoubleType, true) :: Nil)
     val testDF = sqlContext.createDataFrame(testRDD, testSchema)
-    val testMat = RowParitionedMatrix.fromDataFrame(testDF)
+    val testMat = RowPartitionedMatrix.fromDataFrame(testDF)
     val rowProducts = testMat.reduceRowElements(_ * _)
 
-    assert(rowProducts.collect().toArray === Array(6, -9, 0, 0),
+    assert(rowProducts.collect().toArray === Array(6.0, -9.0, 0.0, 0.0),
       "reduceRowElements() does not return correct answers!")
     assert(rowProducts.numRows() === 4, "reduceRowElements() returns a result with incorrect row count!")
     assert(rowProducts.numCols() === 1, "reduceRowElements() returns a result with incorrect col count!")


### PR DESCRIPTION
One underlying question I have is what is the most efficient way of getting data out of the Row objects created by map. The current work line of code is: 
val matrixRDD = df.map(x => x.toSeq.toArray).map(y => y.map(z => z.asInstanceOf[Double])