### PR TITLE
add synchronization primitive around DORMQR call to make thread safe

### DIFF
--- a/src/main/scala/edu/berkeley/cs/amplab/mlmatrix/util/QRUtils.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/mlmatrix/util/QRUtils.scala
@@ -138,9 +138,10 @@ object QRUtils {
 
     val lwork1 = if(info.`val` != 0) result.cols else work(0).toInt
     val workspace = new Array[Double](lwork1)
-
-    lapack.dormqr("L", trans, result.rows, result.cols, T.length, Y.data, Y.rows, T,
-      result.data, result.rows, workspace, workspace.length, info)
+    QRUtils.synchronized {
+      lapack.dormqr("L", trans, result.rows, result.cols, T.length, Y.data, Y.rows, T,
+        result.data, result.rows, workspace, workspace.length, info)
+    }
 
     if (info.`val` > 0)
       throw new NotConvergedException(NotConvergedException.Iterations)

--- a/src/main/scala/edu/berkeley/cs/amplab/mlmatrix/util/QRUtils.scala
+++ b/src/main/scala/edu/berkeley/cs/amplab/mlmatrix/util/QRUtils.scala
@@ -138,6 +138,7 @@ object QRUtils {
 
     val lwork1 = if(info.`val` != 0) result.cols else work(0).toInt
     val workspace = new Array[Double](lwork1)
+    // NOTE: Synchronize access to dormqr as it is not always thread safe
     QRUtils.synchronized {
       lapack.dormqr("L", trans, result.rows, result.cols, T.length, Y.data, Y.rows, T,
         result.data, result.rows, workspace, workspace.length, info)


### PR DESCRIPTION
Some bug reports associated with the DORMQR thread safety issue:
- https://icl.cs.utk.edu/lapack-forum/viewtopic.php?f=2&t=867
- http://lists.opensuse.org/opensuse-bugs/2015-02/msg03135.html
- http://wwwf.imperial.ac.uk/~mab201/20120814.html

Also, it looks like there was a fix checked in for this here: https://github.com/live-clones/lapack/commit/5982aff1cdd9b4cdad904212a55fd504fa857cb7 -- but we are not sure which LAPACK version this will come out as. 
